### PR TITLE
サーバのIP選択機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ FTPは暗号化をせずに通信します．想定用途外でのファイル�
 本ソフトウェアの利用に際し受けた損害についての責任は，一切負いかねますので予めご了承ください．
 
 # Requirement
-pip install piftpdlib
+pip install pyftpdlib

--- a/ftp_server.py
+++ b/ftp_server.py
@@ -4,13 +4,15 @@ import pyftpdlib.handlers
 import pyftpdlib.servers
 import sys
 
+ip_address = # your NIC's ip address
+port = # free (21 is default value)
 # コマンドライン引数の判断
 args = sys.argv
 argvlen =len(sys.argv)
-if argvlen > 0:
+if argvlen > 1:
     directory = args[1]
-if argvlen < 1:
-    directory = 'C:/Users/shou/Desktop/programming/network_programming'
+if argvlen < 2:
+    directory = 'C:\\Users\\akira\\Desktop\\network_ftp'
 
 # 認証ユーザーを作る
 authorizer = pyftpdlib.authorizers.DummyAuthorizer()
@@ -21,5 +23,5 @@ handler = pyftpdlib.handlers.FTPHandler
 handler.authorizer = authorizer
 
 # FTPサーバーを立ち上げる
-server = pyftpdlib.servers.FTPServer(("127.0.0.1", 21), handler)
+server = pyftpdlib.servers.FTPServer((ip_address, port), handler)
 server.serve_forever()

--- a/ftp_server_prototype.py
+++ b/ftp_server_prototype.py
@@ -21,6 +21,7 @@ main_frm = ttk.Frame(main_win)
 main_frm.grid(column=0, row=0, sticky=tkinter.NSEW, padx=5, pady=10)
 
 def open():
+    ip_address = ip_box.get()
     port = port_box.get()
     user = user_box.get()
     password = password_box.get()
@@ -36,7 +37,7 @@ def open():
 
     # FTPサーバーを立ち上げる
     global server
-    server = pyftpdlib.servers.FTPServer(("127.0.0.1", port), handler)
+    server = pyftpdlib.servers.FTPServer((ip_address, port), handler)
     server.serve_forever()
 
 def folder():
@@ -49,7 +50,7 @@ def stop():
 
 def disp(): # サーバ接続情報確認ホップアップ
     ip = socket.gethostbyname(socket.gethostname())
-    disp_serverinfo.main(ip,port_box.get(),user_box.get(),password_box.get())
+    disp_serverinfo.main(ip_box.get(),port_box.get(),user_box.get(),password_box.get())
 
 def exit_button(): # ×ボタンが押下された際の終了処理
     if messagebox.askokcancel("Quit", "Do you want to quit?"):
@@ -64,6 +65,10 @@ folder_path = tkinter.StringVar()
 folder_label = ttk.Label(main_frm, text="フォルダ指定")
 folder_box = ttk.Entry(main_frm, textvariable = folder_path)
 folder_btn = ttk.Button(main_frm, text="参照", command = folder)
+
+# ウィジェット作成(IPアドレス)
+ip_label = ttk.Label(main_frm, text="公開先IPアドレス")
+ip_box = ttk.Entry(main_frm)
 
 # ウィジェット作成(ポート番号)
 port_label = ttk.Label(main_frm, text="ポート番号")
@@ -88,21 +93,26 @@ folder_box.grid(column=1, row=0, sticky=tkinter.EW, padx=5)
 folder_btn.grid(column=2, row=0)
 folder_box.insert(0, os.path.realpath('.'))
 
-port_label.grid(column=0, row=1, pady=10)
-port_box.grid(column=1, row=1, sticky=tkinter.EW, padx=5)
+def_ip = socket.gethostbyname(socket.gethostname())# サーバの自IPアドレスを取得
+ip_label.grid(column=0, row=1, pady=10)
+ip_box.grid(column=1, row=1, sticky=tkinter.EW, padx=5)
+ip_box.insert(0, def_ip)
+
+port_label.grid(column=0, row=2, pady=10)
+port_box.grid(column=1, row=2, sticky=tkinter.EW, padx=5)
 port_box.insert(0, "21")
 
-user_label.grid(column=0, row=2, pady=10)
-user_box.grid(column=1, row=2, sticky=tkinter.EW, padx=5)
+user_label.grid(column=0, row=3, pady=10)
+user_box.grid(column=1, row=3, sticky=tkinter.EW, padx=5)
 user_box.insert(0, "user")
 
-password_label.grid(column=0, row=3, pady=10)
-password_box.grid(column=1, row=3, sticky=tkinter.EW, padx=5)
+password_label.grid(column=0, row=4, pady=10)
+password_box.grid(column=1, row=4, sticky=tkinter.EW, padx=5)
 password_box.insert(0, "password")
 
-ftp_open.grid(column=1, row=4, sticky=tkinter.W, padx=90)
-ftp_close.grid(column=1, row=4, sticky=tkinter.E, padx=90)
-disp_info.grid(column=1, row=5, sticky=tkinter.S, padx=90)
+ftp_open.grid(column=1, row=5, sticky=tkinter.W, padx=90)
+ftp_close.grid(column=1, row=5, sticky=tkinter.E, padx=90)
+disp_info.grid(column=1, row=6, sticky=tkinter.S, padx=90)
 
 # 配置設定
 main_win.columnconfigure(0, weight=1)


### PR DESCRIPTION
prototypeの「pyftpdlib.servers.FTPServer」の引数のIPアドレスをローカルループバックアドレスにすると自サーバ以外からはアクセス不可能なので対策しました